### PR TITLE
Image variance added as a public property

### DIFF
--- a/src/main/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckAwt.java
+++ b/src/main/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckAwt.java
@@ -28,7 +28,7 @@ import javax.imageio.ImageIO;
 * 
 * @author EDINA
 */
-public class BlurCheckAwt extends BlurCheckRunnable{
+public class BlurCheckAwt extends BlurCheckRunnable {
         /*********/
         private BufferedImage original;
         
@@ -106,7 +106,7 @@ public class BlurCheckAwt extends BlurCheckRunnable{
         }
 
         private boolean getPassDecision( BufferedImage img ){
-            long variance = getVariance(img);
+            this.variance = getVariance(img);
             dbg("Variance is : " + variance);
             return variance > threshold;
         }

--- a/src/main/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckRunnable.java
+++ b/src/main/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckRunnable.java
@@ -24,8 +24,10 @@ public abstract class BlurCheckRunnable implements Runnable {
         /* the actual Kernel. Any 3x3 kernel should work here for experimentation e.g. {-1,-1,-1,-1,8,-1,-1,-1,-1}  */
         public static final float LAPLACE_KERNEL[]={0,-1,0,-1,4,-1,0,-1,0};
         /* Check this after the test is run for the result. This is null if process has not yet been "run()" */
-        public Boolean pass;
-
+        public Boolean pass; //Whether the image passed blur check threshold
+        public long variance; //Laplace variance value of the image
+        
+        
         /*********/
 
         protected File file;

--- a/src/main/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckRunnable.java
+++ b/src/main/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckRunnable.java
@@ -44,6 +44,7 @@ public abstract class BlurCheckRunnable implements Runnable {
         /** Theshold is the desired variance i.e. the higher the sharper ( 1500 is a good start) */ 
         public BlurCheckRunnable(File imageFile, int threshold, boolean debug){
             this.pass = null;
+            this.variance = 0;
             this.file = imageFile;
             this.threshold = threshold;
             this.debug = debug;
@@ -51,6 +52,7 @@ public abstract class BlurCheckRunnable implements Runnable {
 
 		public BlurCheckRunnable(int threshold, boolean debug) {
 			this.pass = null;
+			this.variance = 0;
 			this.file = null;
 			this.threshold = threshold;
             this.debug = debug;

--- a/src/test/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckAwtTest.java
+++ b/src/test/java/eu/cobwebproject/qa/automaticvalidation/BlurCheckAwtTest.java
@@ -47,6 +47,7 @@ public class BlurCheckAwtTest extends TestCase {
             
             BlurCheckAwt lap = new BlurCheckAwt(testImage, threshold, debug);
             lap.run();
+            System.out.println("hello: " + lap.variance);
             assertFalse(lap.pass);
         }
         catch(URISyntaxException ex){
@@ -62,6 +63,7 @@ public class BlurCheckAwtTest extends TestCase {
             File testImage = new File(url.toURI());
             BlurCheckAwt lap = new BlurCheckAwt(testImage, threshold, debug);
             lap.run();
+            System.out.println("hello: " + lap.variance);
             assertTrue(lap.pass);
         }
         catch(URISyntaxException ex){


### PR DESCRIPTION
I have exposed the variance calculated by the getPassDecision as a public property to enable that value to be used for metadata recording.
